### PR TITLE
Change newsapi to another api

### DIFF
--- a/dinosaur-app/src/components/DinosaurDetails.jsx
+++ b/dinosaur-app/src/components/DinosaurDetails.jsx
@@ -44,7 +44,7 @@ const DinosaurDetails = () => {
                 <p>{new Date(data.published_at).toLocaleString('en-CA', { dateStyle: 'short', hour12: false, timeStyle: 'short' })}</p>
                 <p>Source: {data.source}</p>
                 <div dangerouslySetInnerHTML={{ __html: data.description }} />
-                <a href={data.url} className="btn btn-link btn-sm">Read more</a>
+                <a href={data.url} target="_blank" rel="noopener noreferrer" className="btn btn-link btn-sm">Read more</a>
               </div>
             ))
           ) : (

--- a/dinosaur-app/src/components/DinosaurDetails.jsx
+++ b/dinosaur-app/src/components/DinosaurDetails.jsx
@@ -8,6 +8,7 @@ const DinosaurDetails = () => {
   const { id } = useParams();
   const dinosaur = dinosaurs.find(dino => dino.id === parseInt(id));
   const [news, setNews] = useState([]);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchNews = async () => {
@@ -18,6 +19,9 @@ const DinosaurDetails = () => {
         setNews(response.data.data.slice(0, 2));
       } catch (error) {
         console.error("Error fetching news:", error);
+        if (error.code === 'usage_limit_reached') {
+          setError("We have reached our daily API request limit. Please try again tomorrow.");
+        }
       }
     };
     fetchNews();
@@ -48,6 +52,8 @@ const DinosaurDetails = () => {
                 <a href={data.url} target="_blank" rel="noopener noreferrer" className="btn btn-link btn-sm">Read more</a>
               </div>
             ))
+          ) : error ? (
+            <p>{error}</p>
           ) : (
             <p>{"Sorry, we couldn't find any news articles about " + dinosaur.name + "."}</p>
           )}

--- a/dinosaur-app/src/components/DinosaurDetails.jsx
+++ b/dinosaur-app/src/components/DinosaurDetails.jsx
@@ -13,9 +13,9 @@ const DinosaurDetails = () => {
     const fetchNews = async () => {
       try {
         const response = await axios.get(
-          `https://newsapi.org/v2/everything?q=${dinosaur.name}&apiKey=${import.meta.env.VITE_NEWS_API_KEY}`
+          `https://api.thenewsapi.com/v1/news/all?api_token=${import.meta.env.VITE_THE_NEWS_API_KEY}&search=${dinosaur.name}&language=en`
         );
-        setNews(response.data.articles.slice(0, 2));
+        setNews(response.data.data.slice(0, 2));
       } catch (error) {
         console.error("Error fetching news:", error);
       }
@@ -38,14 +38,13 @@ const DinosaurDetails = () => {
             <li className="list-group-item" style={{ backgroundColor: '#eafaea' }}>Found In: {dinosaur.foundIn}</li>
           </ul>
           {news.length > 0 ? (
-            news.map((article, index) => (
+            news.map((data, index) => (
               <div key={index} style={{ border: '1px solid #000' }}>
-                <h5>{article.title}</h5>
-                <p>{new Date(article.publishedAt).toLocaleString('en-CA', { dateStyle: 'short', hour12: false, timeStyle: 'short' })}</p>
-                <p>Source: {article.source.name}</p>
-                <p>Author: {article.author}</p>
-                <div dangerouslySetInnerHTML={{ __html: article.content }} />
-                <a href={article.url} className="btn btn-link btn-sm">Read more</a>
+                <h5>{data.title}</h5>
+                <p>{new Date(data.published_at).toLocaleString('en-CA', { dateStyle: 'short', hour12: false, timeStyle: 'short' })}</p>
+                <p>Source: {data.source}</p>
+                <div dangerouslySetInnerHTML={{ __html: data.description }} />
+                <a href={data.url} className="btn btn-link btn-sm">Read more</a>
               </div>
             ))
           ) : (

--- a/dinosaur-app/src/components/DinosaurDetails.jsx
+++ b/dinosaur-app/src/components/DinosaurDetails.jsx
@@ -43,6 +43,7 @@ const DinosaurDetails = () => {
                 <h5>{data.title}</h5>
                 <p>{new Date(data.published_at).toLocaleString('en-CA', { dateStyle: 'short', hour12: false, timeStyle: 'short' })}</p>
                 <p>Source: {data.source}</p>
+                <img src={data.image_url} alt={data.title} width="300" height="200" />
                 <div dangerouslySetInnerHTML={{ __html: data.description }} />
                 <a href={data.url} target="_blank" rel="noopener noreferrer" className="btn btn-link btn-sm">Read more</a>
               </div>


### PR DESCRIPTION
In this PR, I have made the following changes: 
- Switched to [THE NEWS API](https://www.thenewsapi.com/documentation) for news data
- News source links now open in a new tab
- News images are now displayed
- Added error handling for API usage limit (Daily limit of THE NEWS API is 100 requests)

Please review these changes and provide your feedback.

You must create a .env file in the project's root directory and reference the environment variable VITE_THE_NEWS_API_KEY.  I can share the value of the environmental variables with you.

https://harmeetar.atlassian.net/jira/software/projects/DINO/boards/3?selectedIssue=DINO-14